### PR TITLE
Use path to ensure that linux can find the files

### DIFF
--- a/.eslintrc.browser.js
+++ b/.eslintrc.browser.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   root: true,
   env: {
@@ -6,7 +8,7 @@ module.exports = {
   parser: 'vue-eslint-parser',
   parserOptions: {
     parser: '@typescript-eslint/parser',
-    project: 'tsconfig.browser.json',
+    project: path.join(__dirname, 'tsconfig.browser.json'),
     extraFileExtensions: ['.vue'],
   },
   globals: {
@@ -28,7 +30,7 @@ module.exports = {
     'import/resolver': {
       typescript: {
         // This is needed to properly resolve paths.
-        project: 'tsconfig.browser.json',
+        project: path.join(__dirname, 'tsconfig.browser.json'),
       },
     },
     'import/extensions': ['.js', '.jsx', '.ts', '.tsx'],

--- a/.eslintrc.extension.js
+++ b/.eslintrc.extension.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   root: true,
   env: {
@@ -5,7 +7,7 @@ module.exports = {
   },
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: 'tsconfig.extension.json',
+    project: path.join(__dirname, 'tsconfig.extension.json'),
   },
   plugins: [
     '@typescript-eslint',
@@ -21,7 +23,7 @@ module.exports = {
     'import/resolver': {
       typescript: {
         // This is needed to properly resolve paths.
-        project: 'tsconfig.extension.json',
+        project: path.join(__dirname, 'tsconfig.extension.json'),
       },
     },
     'import/extensions': ['.js', '.jsx', '.ts', '.tsx'],


### PR DESCRIPTION
When compiling the typescript files on Linux, eslint etc are trying to find these configuration files relative to `/src/dashboard`. I am not sure why this is the case, but by using `__dirname` we ensure that the configuration files are searched for in the correct location